### PR TITLE
Add Development server to Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # reso_webapi_js
+
+## Development
+
+Service for testing requests: [https://services.odata.org/V4/OData/OData.svc/Products](https://services.odata.org/V4/OData/OData.svc/Products)


### PR DESCRIPTION
Add **Development** server to Heroku free account to test requests from the client.
Also, add a Development section to _README_ how to test requests via RESO api server from heroku.
P.S. Link: https://github.com/NationalAssociationOfRealtors/reso-api-server
